### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-backend.yml
+++ b/.github/workflows/build-backend.yml
@@ -12,6 +12,9 @@ on:
       - 'backend/**'
       - '.github/workflows/build-backend.yml'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/serbathome/ddns/security/code-scanning/3](https://github.com/serbathome/ddns/security/code-scanning/3)

In general, the fix is to explicitly declare a `permissions` block to constrain the `GITHUB_TOKEN` to the least privileges needed. For this workflow, the steps only need to read the repository contents (for `actions/checkout`) and do not require any write access to the GitHub repository itself, so `contents: read` is sufficient.

The best minimal fix without changing functionality is to add a root‑level `permissions` section applying to all jobs in `.github/workflows/build-backend.yml`. Place it after the `on:` block and before `jobs:`. This ensures that every job (currently just `build`) runs with `GITHUB_TOKEN` limited to `contents: read`. No other imports, secrets, or steps need to be modified.

Concretely:
- Edit `.github/workflows/build-backend.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

between the trigger section (`on: ...`) and the `jobs:` definition. No additional methods or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
