### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -1,5 +1,8 @@
 name: Build Frontend
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/serbathome/ddns/security/code-scanning/4](https://github.com/serbathome/ddns/security/code-scanning/4)

In general, the fix is to explicitly define a `permissions` block for the workflow or specific jobs to restrict the `GITHUB_TOKEN` to the least privileges needed. For this workflow, the job only needs to read repository contents to perform `actions/checkout`; all container registry operations use Azure credentials stored in `vars` and `secrets`, not the GitHub token.

The best fix here is to add a top‑level `permissions` block with `contents: read`. This will apply to all jobs (there is only one, `build`) and will override any broader repository default permissions, ensuring `GITHUB_TOKEN` is read‑only for repository contents. No steps need to change and no new imports or dependencies are required. Concretely, in `.github/workflows/build-frontend.yml`, insert:

```yaml
permissions:
  contents: read
```

right after the `name: Build Frontend` line (before `on:`). This satisfies CodeQL’s recommendation and enforces least privilege without altering the workflow’s existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
